### PR TITLE
SW-318. Remove last_rx_byte in moteprobe

### DIFF
--- a/openvisualizer/main.py
+++ b/openvisualizer/main.py
@@ -114,7 +114,7 @@ class OpenVisualizerServer(SimpleXMLRPCServer):
     """
 
     def __init__(self, host, port, webserver, simulator_mode, debug, vcdlog, use_page_zero, sim_topology, iotlab_motes,
-                 testbed_motes, mqtt_broker, opentun, fw_path, auto_boot, root, port_mask):
+                 testbed_motes, mqtt_broker, opentun, fw_path, auto_boot, root, port_mask, baudrate):
 
         # store params
         self.host = host
@@ -187,7 +187,8 @@ class OpenVisualizerServer(SimpleXMLRPCServer):
 
             self.mote_probes = [
                 moteprobe.MoteProbe(mqtt_broker, serial_port=p)
-                for p in moteprobe.find_serial_ports(port_mask=self.port_mask)
+                for p in moteprobe.find_serial_ports(port_mask=self.port_mask,
+                                                     baudrate=self.baudrate)
            ]
 
         # create a MoteConnector for each MoteProbe
@@ -618,6 +619,15 @@ def _add_parser_args(parser):
     )
 
     parser.add_argument(
+        '--baudrate',
+        dest='baudrate',
+        default=[115200],
+        action='store',
+        nargs='+',
+        help='List of baudrates to probe for, e.g 115200 500000'
+    )
+
+    parser.add_argument(
         '--no-boot',
         dest='auto_boot',
         default=True,
@@ -687,6 +697,8 @@ def main():
 
     if args.port_mask:
         options.append('serial port mask        = {0}'.format(args.port_mask))
+    if args.baudrate:
+        options.append('baudrates to probe      = {0}'.format(args.baudrate))
 
     if args.testbed_motes:
         options.append('opentestbed             = {0}'.format(args.testbed_motes))
@@ -706,6 +718,7 @@ def main():
         vcdlog=args.vcdlog,
         sim_topology=args.sim_topology,
         port_mask=args.port_mask,
+        baudrate=args.baudrate,
         iotlab_motes=args.iotlab_motes,
         testbed_motes=args.testbed_motes,
         mqtt_broker=args.mqtt_broker,

--- a/openvisualizer/motehandler/moteprobe/moteprobe.py
+++ b/openvisualizer/motehandler/moteprobe/moteprobe.py
@@ -238,7 +238,7 @@ class MoteProbe(threading.Thread):
 
         # local variables
         self.hdlc = openhdlc.OpenHdlc()
-        self.last_rx_byte = self.hdlc.HDLC_FLAG
+        self.last_rx_byte = None
         self.is_receiving = False
         self.input_buf = ''
         self.output_buf = []
@@ -348,6 +348,10 @@ class MoteProbe(threading.Thread):
                                     log.debug("{0}: {2} dehdlcized input: {1}".format(
                                         self.name, format_string_buf(self.input_buf), format_string_buf(temp_buf)))
 
+                                # on valid frame discard HDLC_FLAG end of frame
+                                # byte to not be cosidered as a start of frame
+                                # HDLC_FLAG
+                                rx_byte = None
                             except openhdlc.HdlcException as err:
                                 log.warning('{0}: invalid serial frame: {2} {1}'.format(
                                     self.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cbor
 hkdf
 paho-mqtt
 scapy
-pytest
+pytest==4.6.9
 coloredlogs
 verboselogs
 click

--- a/tests/fw/test_fw_frag.py
+++ b/tests/fw/test_fw_frag.py
@@ -1,52 +1,19 @@
 import logging
-import xmlrpclib
 
 import pytest
 from Crypto.Random.random import randint
-from ipaddr import IPv6Address
 from scapy.compat import raw
 from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest, ICMPv6EchoReply
+
+from tests.conftest import is_my_icmpv6
 
 log = logging.getLogger(__name__)
 
 # =========================== defines ==========================================
 
 NH_ICMPV6 = 58
+
 LOCAL_ADDR = "cccc::2"
-ADDRESSES = []
-HOST = "localhost"
-PORT = 9000
-PREFIX = "bbbb:0:0:0:1415:92cc:0:"
-
-# ============================ helpers & setup code =============================
-
-url = 'http://{}:{}'.format(HOST, str(PORT))
-rpc_server = xmlrpclib.ServerProxy(url)
-mote_ids = rpc_server.get_mote_dict().keys()
-try:
-    root = ''.join(['%02x' % b for b in rpc_server.get_dagroot()])
-except TypeError:
-    pytest.exit("Openvisualizer has no dagroot configured!")
-else:
-    mote_ids.remove(root)
-ADDRESSES.extend([PREFIX + str(int(id)) for id in mote_ids])
-log.info("Running {} with mote addresses: {}".format(__name__, ADDRESSES))
-
-
-# =========================== fixtures =========================================
-
-@pytest.fixture(params=ADDRESSES)
-def mote_addr(request):
-    return request.param
-
-
-def is_my_icmpv6(ipv6_pkt, his_address, my_address):
-    if IPv6Address(ipv6_pkt.src).exploded == IPv6Address(his_address).exploded and \
-            IPv6Address(ipv6_pkt.dst).exploded == IPv6Address(my_address).exploded and \
-            ipv6_pkt.nh == NH_ICMPV6:
-        return True
-    else:
-        return False
 
 
 # ============================ tests ===========================================
@@ -71,7 +38,7 @@ def test_basic_6lo_fragmentation(etun, mote_addr, payload_len):
     timeout = True
     for recv_pkt in received:
         ipv6_pkt = IPv6(recv_pkt)
-        if is_my_icmpv6(ipv6_pkt, mote_addr, LOCAL_ADDR):
+        if is_my_icmpv6(ipv6_pkt, mote_addr, LOCAL_ADDR, NH_ICMPV6):
             timeout = False
             icmp = ICMPv6EchoReply(raw(ipv6_pkt)[40:])
             # check if icmp headers match

--- a/tests/fw/test_fw_udp.py
+++ b/tests/fw/test_fw_udp.py
@@ -1,0 +1,77 @@
+import logging
+from random import randint
+
+import pytest
+from scapy.compat import raw
+from scapy.layers.inet import UDP
+from scapy.layers.inet6 import IPv6
+
+from tests.conftest import is_my_icmpv6
+
+logger = logging.getLogger(__name__)
+
+# =========================== defines ==========================================
+LOCAL_ADDR = 'cccc::2'
+UDP_ECHO_PORT = 7
+
+NH_UDP = 17
+
+
+# ============================ tests ===========================================
+
+@pytest.mark.parametrize("payload_len", range(10, 60, 10))
+def test_udp_echo(etun, mote_addr, payload_len):
+    local_sport = randint(1024, 65355)
+
+    ip = IPv6(src=LOCAL_ADDR, dst=mote_addr, hlim=64)
+    udp = UDP(sport=local_sport, dport=UDP_ECHO_PORT)
+    pkt = ip / udp
+
+    payload = "".join([chr(randint(0, 255))] * payload_len)
+    pkt.add_payload(payload)
+
+    etun.write(list(bytearray(raw(pkt))))
+    received = etun.read(dest=LOCAL_ADDR, timeout=5)
+
+    timeout = True
+    for recv_pkt in received:
+        ipv6_pkt = IPv6(recv_pkt)
+        if is_my_icmpv6(ipv6_pkt, mote_addr, LOCAL_ADDR, NH_UDP):
+            timeout = False
+            udp = UDP(raw(ipv6_pkt)[40:])
+            assert udp.sport == UDP_ECHO_PORT
+            assert udp.dport == local_sport
+
+    if timeout:
+        # node to failed to respond with an ICMPv6 echo before timeout
+        pytest.fail("Timeout on ICMPv6 Echo Response!")
+
+
+@pytest.mark.xfail(reason='Invalid checksum')
+def test_udp_checksum(etun, mote_addr):
+    local_sport = randint(1024, 65355)
+
+    ip = IPv6(src=LOCAL_ADDR, dst=mote_addr, hlim=64)
+    udp = UDP(sport=local_sport, dport=UDP_ECHO_PORT)
+    pkt = ip / udp
+
+    payload = "".join([chr(randint(0, 255))] * 30)
+    pkt.add_payload(payload)
+    logger.info("Reseting checksum")
+    pkt[UDP].chksum = 0
+
+    etun.write(list(bytearray(raw(pkt))))
+    received = etun.read(dest=LOCAL_ADDR, timeout=10)
+
+    timeout = True
+    for recv_pkt in received:
+        ipv6_pkt = IPv6(recv_pkt)
+        if is_my_icmpv6(ipv6_pkt, mote_addr, LOCAL_ADDR, NH_UDP):
+            timeout = False
+            udp = UDP(raw(ipv6_pkt)[40:])
+            assert udp.sport == UDP_ECHO_PORT
+            assert udp.dport == local_sport
+
+    if timeout:
+        # node to failed to respond with an ICMPv6 echo before timeout
+        pytest.fail("Timeout on ICMPv6 Echo Response!")


### PR DESCRIPTION
When processing incoming bytes to determine the start of a frame
a check is performed to see if the the last byte was a HDLC_FLAG
and if the current one is not an HDLC flag.

This works if flowcontrol is handled before the bytes are received
otherwise the handling can consider a HDLC frame end flag and
XON/XOFF bytes as the start of a new frame which is incorrect.

Instead directly check the value of the rx_byte and match against
HDLC to termine the start of a frame.

### Testing

- still works on hw with `openmote-b`

```
→ openv-server

 ___                 _ _ _  ___  _ _
| . | ___  ___ ._ _ | | | |/ __>| \ |
| | || . \/ ._>| ' || | | |\__ \|   |
`___'|  _/\___.|_|_||__/_/ <___/|_\_|
     |_|                  openwsn.org

09:50:10 [OpenVisualizerServer:VERBOSE] Loading logging configuration: config/logging.conf
09:50:10 [OpenVisualizerServer:INFO] Initializing OV Server with options:
                - use page zero           = False
                - use VCD logger          = False
09:50:12 [MoteProbe:SUCCESS] discovered following serial-port(s): ['/dev/ttyUSB1@115200']
09:50:12 [OpenVisualizerServer:INFO] Extracting firmware definitions.
09:50:12 [Utils:VERBOSE] Extracting firmware component names
09:50:12 [Utils:VERBOSE] Generating firmware log descriptions.
09:50:12 [Utils:VERBOSE] Extracting 6top return codes.
09:50:12 [Utils:VERBOSE] Extracting 6top states.
09:50:12 [OpenVisualizerServer:INFO] Starting RPC server
09:50:13 [RPL:INFO] registering DAGroot 00-12-4b-00-14-b5-b5-af
```